### PR TITLE
Remove unneccesary `to_str()` calls in macro code

### DIFF
--- a/cached_proc_macro/src/cached.rs
+++ b/cached_proc_macro/src/cached.rs
@@ -88,7 +88,7 @@ pub fn cached(args: TokenStream, input: TokenStream) -> TokenStream {
 
     // make the cache identifier
     let cache_ident = match args.name {
-        Some(ref name) => Ident::new(name.as_str(), fn_ident.span()),
+        Some(ref name) => Ident::new(name, fn_ident.span()),
         None => Ident::new(&fn_ident.to_string().to_uppercase(), fn_ident.span()),
     };
 
@@ -131,10 +131,10 @@ pub fn cached(args: TokenStream, input: TokenStream) -> TokenStream {
             (cache_ty, cache_create)
         }
         (false, None, None, Some(type_str), Some(create_str), _) => {
-            let ty = parse_str::<Type>(type_str.as_str()).expect("unable to parse cache type");
+            let ty = parse_str::<Type>(type_str).expect("unable to parse cache type");
 
-            let cache_create = parse_str::<Block>(create_str.as_str())
-                .expect("unable to parse cache create block");
+            let cache_create =
+                parse_str::<Block>(create_str).expect("unable to parse cache create block");
 
             (quote! { #ty }, quote! { #cache_create })
         }

--- a/cached_proc_macro/src/helpers.rs
+++ b/cached_proc_macro/src/helpers.rs
@@ -102,17 +102,16 @@ pub(super) fn make_cache_key_type(
 ) -> (TokenStream2, TokenStream2) {
     match (key, convert, ty) {
         (Some(key_str), Some(convert_str), _) => {
-            let cache_key_ty =
-                parse_str::<Type>(key_str.as_str()).expect("unable to parse cache key type");
+            let cache_key_ty = parse_str::<Type>(key_str).expect("unable to parse cache key type");
 
-            let key_convert_block = parse_str::<Block>(convert_str.as_str())
-                .expect("unable to parse key convert block");
+            let key_convert_block =
+                parse_str::<Block>(convert_str).expect("unable to parse key convert block");
 
             (quote! {#cache_key_ty}, quote! {#key_convert_block})
         }
         (None, Some(convert_str), Some(_)) => {
-            let key_convert_block = parse_str::<Block>(convert_str.as_str())
-                .expect("unable to parse key convert block");
+            let key_convert_block =
+                parse_str::<Block>(convert_str).expect("unable to parse key convert block");
 
             (quote! {}, quote! {#key_convert_block})
         }


### PR DESCRIPTION
These types all seem to be &String, so I don't think the to_str() call does anything useful